### PR TITLE
[fix] 글챌린지 시작 API 수정, 토큰 기한 설정, 챌린지 갯수 설정

### DIFF
--- a/src/controllers/writeController.ts
+++ b/src/controllers/writeController.ts
@@ -5,9 +5,12 @@ import { prisma } from '@prisma/client';
 import { imagesArrayDTO, videoArrayDTO } from '../interfaces/DTO'
 import { Console } from 'console';
 
-
+import { getKoreanDateISOStringAdd9Hours } from '../modules/koreanTime';
 export const newChallenge = async (req: any, res: Response, next: NextFunction) => {
     try {
+        const koreanDateISOString2 = getKoreanDateISOStringAdd9Hours();
+        const koreanTime2 = new Date(koreanDateISOString2)
+        console.log(koreanTime2);
         const newChallenge: string = req.params.name;
         const data = await ChallengeController.newChallengeData(req.decoded.id, newChallenge);
         const challengesCount: number = data?.challengesCount as number;
@@ -38,7 +41,7 @@ export const newChallenge = async (req: any, res: Response, next: NextFunction) 
                 });
             }
         } else {
-            if (2 < challengesCount) {
+            if (2 <= challengesCount) {
                 return res.status(418).json({
                     "code": 418,
                     "message": "더 이상 챌린지를 할 수 없습니다.",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,7 +3,7 @@ import dotenv from 'dotenv';
 import morgan from 'morgan';
 import cors from 'cors';
 import {stream} from './modules/loggerHandler';
-import {getKoreanDateISOString} from './modules/koreanTime';
+import {getKoreanDateISOString, getKoreanDateISOStringAdd9Hours} from './modules/koreanTime';
 dotenv.config();
 const app = express();
 const port = process.env.PORT || 3000;
@@ -13,7 +13,9 @@ const port = process.env.PORT || 3000;
   const koreanTime = new Date(koreanDateISOString)
   console.log(koreanTime);
 
-
+  const koreanDateISOString2 = getKoreanDateISOStringAdd9Hours();
+  const koreanTime2 = new Date(koreanDateISOString2)
+  console.log(koreanTime2);
 
 
 app.use(morgan('combined', { stream: stream }));

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -18,14 +18,14 @@ const sign = (userId: string, userRole: number) => {
   };
   return jwt.sign(payload, secret, {
     algorithm: 'HS256',
-    expiresIn: '10m',
+    expiresIn: '14d',
   });
 }
 
 const refresh = () => {
   return jwt.sign({}, secret, {
     algorithm: 'HS256',
-    expiresIn: '30m',
+    expiresIn: '30d',
   });
 }
 const decode = (token: string) => {

--- a/src/modules/koreanTime.ts
+++ b/src/modules/koreanTime.ts
@@ -8,5 +8,13 @@ const getKoreanDateISOString = () =>  {
     return realKoreanDate;
   }
 
+  const getKoreanDateISOStringAdd9Hours = () =>  {
+    const date = new Date();
+    const koreanDate = new Date(date.getTime() + (9 * 60 * 60 * 1000)+ (30 * 24 * 60 * 60 * 1000)); 
+    const realKoreanDate = koreanDate.toISOString().slice(0, 10) + "T00:00:00.000Z";
+ 
+    return realKoreanDate;
+  }
 
-  export {getKoreanDateISOString} 
+
+  export {getKoreanDateISOString, getKoreanDateISOStringAdd9Hours} 

--- a/src/services/challengeService.ts
+++ b/src/services/challengeService.ts
@@ -1,7 +1,7 @@
 import { PrismaClient } from '@prisma/client'
 import { DATA_SOURCES } from '../config/auth';
 import mysql from 'mysql2/promise';
-import { mainChallengeDTO } from '../interfaces/DTO'
+import { mainChallengeDTO } from '../interfaces/DTO';
 const prisma = new PrismaClient();
 
 
@@ -71,7 +71,7 @@ const wholeCategoryData = async () => {
       }
     });
     const challenges = challengesDB.map((e) => {
-      return [{ "title": e.title, "category": e.category.name, "image":e.category.emogi }]
+      return [{ "title": e.title, "category": e.category.name, "image": e.category.emogi }]
     });
     for (var i = 0; i < challenges.length; i++) {
       challengesArray.push(challenges[i][0]);
@@ -331,172 +331,13 @@ const afterMainData = async (user_id: number) => {
   }
 }
 
-const newChallengeData = async (user_id: number, newChallenge: string) => {
-  try {
-    const [userCooponDB, challengesCountDB, challengesOverlapDB] = await Promise.all([
-      await prisma.users.findUnique({
-        where: {
-          user_id: user_id
-        },
-        select: {
-          coopon: true
-        }
-      }),
-      await prisma.user_challenges.aggregate({
-        where: {
-          user_id: user_id
-        },
-        _count: {
-          uchal_id: true
-        }
-      }),
-      await prisma.challenges.findMany({
-        where: {
-          title: newChallenge
-        },
-        select: {
-          user_challenges: {
-            select: {
-              chal_id: true
-            }
-          }
-        }
-      })
-    ])
 
-    const coopon = userCooponDB?.coopon;
-    const challengesCount = challengesCountDB._count.uchal_id;
-    const challengesOverlap = challengesOverlapDB[0].user_challenges[0];
-    prisma.$disconnect();
-    return {
-      coopon,
-      challengesCount,
-      challengesOverlap
-    }
 
-  } catch (error) {
-    prisma.$disconnect();
-    console.log(error);
-  }
-};
 
-const startChallengeData = async (user_id: number, newChallenge: string) => {
-  try {
-    const chalId = await prisma.challenges.findMany({
-      where: {
-        title: newChallenge
-      },
-      select: {
-        chal_id: true
 
-      }
-    });
-    const chalIdData = chalId[0].chal_id;
-    await prisma.user_challenges.create({
-      data: {
-        user_id: user_id,
-        chal_id: chalIdData
-      }
-    });
 
-    prisma.$disconnect();
-    return { chalIdData, newChallenge };
-
-  } catch (error) {
-    console.log(error);
-    prisma.$disconnect();
-    return false;
-  }
-};
-
-const newChallengeResult = async (user_id: number, challenge_id: number, newChallenge: string) => {
-  try {
-    const date = new Date().toLocaleString('en-US', { timeZone: 'Asia/Seoul' });
-    const isoDate = new Date(date).toISOString().slice(0, 10) + "T00:00:00.000Z";
-    const realDate = new Date(isoDate);
-    console.log(realDate);
-    const challengTemplateArray: {
-      challenge: string;
-      category: string;
-      "template-title": string;
-      "template-content": string;
-    }[] = [];
-    const relativeChallengeArray = [];
-
-    const [challengTemplateDB, relativeChallengeDB] = await Promise.all([
-      await prisma.challenges.findMany({
-        where: {
-          chal_id: challenge_id
-        },
-        select: {
-          title: true,
-          category: {
-            select: {
-              name: true
-            },
-          },
-          templates: {
-            select: {
-              title: true,
-              content: true
-            }
-          }
-        }
-      }),
-      await prisma.user_challenges.findMany({
-        where: {
-          user_id: user_id
-        },
-        select: {
-          challenges: {
-            select: {
-              title: true
-            }
-          },
-          user_challenge_templetes: {
-            where: {
-              created_at: realDate,
-            },
-            select: {
-              uctem_id: true
-            }
-          }
-        }
-      })
-    ]);
-    for (var i = 0; i < challengTemplateDB[0].templates.length; i++) {
-      const challengTemplate = challengTemplateDB.map((e) => {
-        return [{
-          "challenge": e.title, "category": e.category.name,
-          "template-title": e.templates[i].title,
-          "template-content": e.templates[i].content
-        }]
-      });
-      challengTemplateArray.push(challengTemplate[0][0]);
-    }
-
-    for (var i = 0; i < relativeChallengeDB.length; i++) {
-      if (!relativeChallengeDB[i].user_challenge_templetes) {
-        const relativeChallengeMap = relativeChallengeDB.map((e) => {
-          return e.challenges;
-        });
-        relativeChallengeArray.push(relativeChallengeMap[i].title);
-      }
-    }
-
-    const valueFilter = relativeChallengeArray.filter((element) => element !== newChallenge);
-    valueFilter.unshift(newChallenge);
-    prisma.$disconnect();
-    return { valueFilter, challengTemplateArray };
-  } catch (error) {
-    console.log(error);
-    prisma.$disconnect();
-  }
-};
 
 export {
   beforeMainData, wholeCategoryData, oneCategoryData,
   manyCategoryData, challengeSearchData, afterMainData,
-  newChallengeData, startChallengeData, newChallengeResult
-
 }

--- a/src/services/writeService.ts
+++ b/src/services/writeService.ts
@@ -2,7 +2,7 @@ import { PrismaClient } from '@prisma/client'
 import { DATA_SOURCES } from '../config/auth';
 import { TemplateDTO } from '../interfaces/DTO';
 import mysql from 'mysql2/promise';
-import { getKoreanDateISOString } from '../modules/koreanTime';
+import { getKoreanDateISOString, getKoreanDateISOStringAdd9Hours } from '../modules/koreanTime';
 const prisma = new PrismaClient();
 
 
@@ -61,6 +61,9 @@ const newChallengeData = async (user_id: number, newChallenge: string) => {
 
 const startChallengeData = async (user_id: number, newChallenge: string) => {
     try {
+        const koreanDateISOStringAdd9Hours = getKoreanDateISOStringAdd9Hours();
+        const koreanTimeAdd9Hours = new Date(koreanDateISOStringAdd9Hours)
+        console.log(koreanTimeAdd9Hours);
         const chalId = await prisma.challenges.findMany({
             where: {
                 title: newChallenge
@@ -73,7 +76,8 @@ const startChallengeData = async (user_id: number, newChallenge: string) => {
         await prisma.user_challenges.create({
             data: {
                 user_id: user_id,
-                chal_id: chalIdData
+                chal_id: chalIdData,
+                finish_at: koreanTimeAdd9Hours
             }
         });
         prisma.$disconnect();
@@ -299,7 +303,7 @@ const writeChallengeData = async (user_id: number) => {
                 }
             }
         }
-        
+
         prisma.$disconnect();
         return { challengeArray }
     } catch (error) {
@@ -417,7 +421,7 @@ const writeTemplateData = async (chal_id: number, uctem_id?: number) => {
                 }
 
             })
-          
+
             const temporaryChallenge = userTemplate;
             prisma.$disconnect();
             return { challengeTemplateDB, categoryDB, temporaryChallenge };
@@ -701,12 +705,12 @@ const selectTemplateData = async (
             templateNameDB[i].image = category[0].image;
         }
         //console.log(templateNameDB)
-        const templates  = templateNameDB.map((e) => {
-            return { "templateTitle": e.title, "templateContent" : e.content, "category":e.category, "image": e.image};
+        const templates = templateNameDB.map((e) => {
+            return { "templateTitle": e.title, "templateContent": e.content, "category": e.category, "image": e.image };
 
         })
 
-       
+
         console.log(templates)
         const challengeCategory = challengeIdCategoryDB[0].category.name;
 


### PR DESCRIPTION
## Solved Issue

close #59 
1. 글 챌린지 시작 API 수정
2. 토큰 기한 accessToken : 14d, refreshToken : 30d
3. 쿠폰 없을 경우 챌린지 최대 2개

<br>

## Motivation

-

<br>

## Key Changes

-

<br>

## To Reviewers

-